### PR TITLE
allow keywords w/ other capitalization to exist

### DIFF
--- a/http/classes/class_wms.php
+++ b/http/classes/class_wms.php
@@ -2773,7 +2773,7 @@ SQL;
 			$keyword_id = "";
 			
 			while ($keyword_id == "") {
-				$sql = "SELECT keyword_id FROM keyword WHERE UPPER(keyword) = UPPER($1)";
+				$sql = "SELECT keyword_id FROM keyword WHERE keyword = $1";
 				$v = array($k[$j]);
 				$t = array('s');
 				$res = db_prep_query($sql,$v,$t);


### PR DESCRIPTION
fix #77

After applying this fix keywords will not be changed, 
when capitalization is changed in the admin interface.
Instead the keyword will be recognized as a new keyword.