### PR TITLE
featureinfo_w_o_unnamed_layers

### DIFF
--- a/http/javascripts/map_obj.js
+++ b/http/javascripts/map_obj.js
@@ -1011,7 +1011,7 @@ Mapbender.Map = function (options) {
 			if (typeof(featureInfoRequest) !== 'undefined' && featureInfoRequest !== "" && featureInfoRequest !== false) {
 				//iterate over all layers to select those which are queryable and active which lie in the region
 				for (var j = 0; j < this.wms[i].objLayer.length; j++) {
-					if (this.wms[i].objLayer[j].gui_layer_querylayer == 1 && this.wms[i].objLayer[j].gui_layer_queryable == 1) {
+					if (this.wms[i].objLayer[j].gui_layer_querylayer == 1 && this.wms[i].objLayer[j].gui_layer_queryable == 1 && !this.wms[i].objLayer[j].layer_name.startsWith('unnamed_layer')) {
 						var bbox = this.objectFindByKey(this.wms[i].objLayer[j].layer_epsg, "epsg", epsg);
 						if (bbox) {
 							//check if clicked point is in bbox of layer
@@ -1062,7 +1062,7 @@ Mapbender.Map = function (options) {
 			//get all layers for this wms which have activated featureInfo Button
 			//loop over all layers of this wms
 	 		for (var j = 0; j < this.wms[i].objLayer.length; j++) {
-				if (this.wms[i].objLayer[j].gui_layer_querylayer == 1 && this.wms[i].objLayer[j].gui_layer_queryable == 1) {
+				if (this.wms[i].objLayer[j].gui_layer_querylayer == 1 && this.wms[i].objLayer[j].gui_layer_queryable == 1 && !this.wms[i].objLayer[j].layer_name.startsWith('unnamed_layer')) {
 					var featureInfoObj = {};
                    			featureInfoObj.title = this.wms[i].objLayer[j].gui_layer_title;
 					//pull featureinfo request

--- a/http/javascripts/wms.js
+++ b/http/javascripts/wms.js
@@ -533,7 +533,7 @@ wms_const.prototype.getQuerylayers = function(map){
 		this.objLayer[i].gui_layer_minscale <= currentScale &&
 		(this.objLayer[i].gui_layer_maxscale >= currentScale ||
 			this.objLayer[i].gui_layer_maxscale === 0);
-		if(this.objLayer[i].gui_layer_querylayer === 1 && !this.objLayer[i].has_childs && isVisible){
+		if(this.objLayer[i].gui_layer_querylayer === 1 && !this.objLayer[i].has_childs && isVisible && !this.objLayer[i].layer_name.startsWith('unnamed_layer') ){
 			queryLayers.push(this.objLayer[i].layer_name);
 		}
 	}


### PR DESCRIPTION
discard unnamed_layers from wms and layer object while featureInfo requests urls are build.
see also #https://github.com/GDI-HE/team-gdi/issues/147