### PR TITLE
Update mod_inspireDownloadFeed.php 

### DIFF
--- a/http/php/mod_inspireDownloadFeed.php
+++ b/http/php/mod_inspireDownloadFeed.php
@@ -1060,7 +1060,7 @@ function generateFeed($feedDoc, $recordId, $generateFrom) {
 			$atomFeedKey .= $layerId;
 		break;
 		case "wfs":
-			$atomFeedKey .= $wfsId;
+			$atomFeedKey .= $featuretypeId;
 			switch ($mapbenderMetadata[$m]->wfs_version) {
 				case "2.0.2":
 					$typeParameterName = "typeNames";


### PR DESCRIPTION
If the same dataset metadata is coupled to multiple featuretypes, only one featuretype is shown in the atomfeed client due to the atomFeedKey being created based on the wfsID