### PR TITLE
Bugfix for css issues in Administration_DE in firefox versions > 120

### DIFF
--- a/http/extensions/jqueryEasyAccordion/jquery.easyAccordion.js
+++ b/http/extensions/jqueryEasyAccordion/jquery.easyAccordion.js
@@ -49,7 +49,11 @@
 		
 		var f = 1;
 		jQuery(this).find('dt').each(function(){
-			jQuery(this).css({'width':dtHeight,'top':dtTop,'margin-left':dtOffset});	
+			if(jQuery.browser.mozilla && parseInt(navigator.userAgent.match(/Firefox\/(\d+)/)[1]) >= 120){
+				jQuery(this).css({'width':dtHeight,'top':dtTop,'margin-left':dtOffset, 'transform-origin':"20px 0px"});
+			}else{
+				jQuery(this).css({'width':dtHeight,'top':dtTop,'margin-left':dtOffset});
+			}	
 			if(settings.slideNum == true){
 				jQuery('<span class="slide-number">'+0+f+'</span>').appendTo(this);
 				if(jQuery.browser.msie){	


### PR DESCRIPTION
In firefox versions > 120 the css attribute -moz-transform-origin is deprecated. Due to that the GUI Administration_DE was broken. The best solution would probably be a library update. Due to dependencies this might be a lot of effort. This quickfix should do it for now.