### PR TITLE
Search api optimization

### DIFF
--- a/http/classes/class_metadata.php
+++ b/http/classes/class_metadata.php
@@ -722,7 +722,7 @@ class searchMetadata
 			if ($countUniqueLayers >= 1) {
 				//Ticket 6655: Changed order of Datasetsearch subservices
 				//als Argument für OrderBy wurde in dem Aufruf 'intern' gesetzt, damit die Layer nach layer_title und wms_id sortiert werden. Dafür wurde oben eine switch - Anweisung um 'intern' erweitert (Zeile 317)
-				$coupledLayers = new self($this->userId, 'dummysearch', '*', null, null, null, null, null, null, null, $countUniqueLayers, null, null, null, $this->languageCode, null, 'wms', 1, 'json', 'internal', null, null, $this->hostName, 'intern', implode(',', $uniqueAllCoupledLayers), $this->restrictToOpenData, $this->originFromHeader, false, $this->https);
+				$coupledLayers = new self($this->userId, 'dummysearch', '*', null, null, null, null, null, null, null, $countUniqueLayers, null, null, null, $this->languageCode, null, 'wms', 1, 'json', 'internal', null, null, $this->hostName, 'intern', implode(',', $uniqueAllCoupledLayers), $this->restrictToOpenData, $this->originFromHeader, false, $this->https, $this->restrictToHvd);
 				$srvCount = 0;
 				foreach (json_decode($coupledLayers->internalResult)->wms->srv as $server) {
 					


### PR DESCRIPTION
Optimizes the loading of dataset search significantly.
Commits were taken from GDI-HE to assure latest changes don't cause any problems when merging. They were implemented there due to a similar requirement to couple the same dataset with more than 10 layers/featuretypes.

Allows 600+ coupled layers to return in less than 20 seconds.
Of course enhances the speed anyway for less coupled layers.

Successfully tested in sl for 6 months and in hessen for 1 week.

Changes the order of coupled layers in dataset search a bit. 
Order: wms_id,layer_pos,layer_title

The returned json-structure differs a bit from the former one, because the hierarchy in this special case is not build since it's not displayed in the front-end.

Due to the parameter "internal" wms search is not affected.

For reference search "Verteilung" in Geoportal SL
Or an a bit less absurd example in Hessen: "Regionalplan"

